### PR TITLE
Allow mock response to be extended as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ expect(mutationResult).toEqual({
   data: {
     updateUser: {
       email: 'nancy@foo.co'
-    } 
+    }
   }
 });
 ```
 
 This allows you to test all the logic of your apollo server, including any logic inside of the `context` option that you can pass to the `ApolloServer` constructor.
 
-### Mocking the `Request` object
+### Mocking the `Request` or `Response` object
 
-`createTestClient` automatically mocks the `Request` object that will be passed to the `context` option of your `ApolloServer` constructor, so testing works out of the box.
-You can also extend the mocked Request object with additional keys by passing an `extendMockRequest` field to `createTestClient`:
+`createTestClient` automatically mocks the `Request` and `Response` objects that will be passed to the `context` option of your `ApolloServer` constructor, so testing works out of the box.
+You can also extend the mocked Request or Response object with additional keys by passing an `extendMockRequest` or `extendMockResponse` field to `createTestClient`:
 
 ```js
 const { query } = createTestClient({
@@ -69,6 +69,13 @@ const { query } = createTestClient({
     headers: {
       cookie: 'csrf=blablabla',
       referer: ''
+    }
+  },
+  extendMockResponse: {
+    locals: {
+      user: {
+        isAuthenticated: false
+      }
     }
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const mockRequest = (options = {}) =>
     ...options
   });
 
-const mockResponse = () => httpMocks.createResponse();
+const mockResponse = (options = {}) => httpMocks.createResponse(options);
 
 type StringOrAst = string | DocumentNode;
 type Options = { variables?: object};
@@ -29,6 +29,12 @@ type TestClientConfig = {
   // If you don't pass anything here, we provide a default request mock object for you.
   // See https://github.com/howardabrams/node-mocks-http#createrequest for all the default values that are included.
   extendMockRequest?: {};
+  // Extends the mocked Response object with additional keys.
+  // Useful when your apolloServer `context` option is a callback that operates on the passed in `res` key,
+  // and you want to inject data into that `res` object (such as `res.locals`).
+  // If you don't pass anything here, we provide a default response mock object for you.
+  // See https://www.npmjs.com/package/node-mocks-http#createresponse for all the default values that are included.
+  extendMockResponse?: {};
 };
 
 // This function takes in an apollo server instance and returns a function that you can use to run operations
@@ -55,14 +61,15 @@ type TestClientConfig = {
 // ```
 export const createTestClient = ({
   apolloServer,
-  extendMockRequest = {}
+  extendMockRequest = {},
+  extendMockResponse = {}
 }: TestClientConfig) => {
   const app = express();
   apolloServer.applyMiddleware({ app });
 
   const test = async (operation: StringOrAst, {variables}: Options = {}) => {
     const req = mockRequest(extendMockRequest);
-    const res = mockResponse();
+    const res = mockResponse(extendMockResponse);
 
     const graphQLOptions = await apolloServer.createGraphQLServerOptions(
       req,


### PR DESCRIPTION
Firstly, thanks for this package!

This change is pretty simple: allow the mock response to be extended the same as mock request can be.

Adds a new optional `extendMockResponse` parameter to `createTestClient`.