### PR TITLE
Update README to reflect we only support apollo-server-express

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ If you want to help out, here's a TODO list:
 
 ## Support
 
-This package should work for consumers using `apollo-server` or `apollo-server-express`. We don't plan on supporting any other node server integrations at this time.
+This package should work for consumers using `apollo-server-express`. We don't plan on supporting any other node server integrations at this time.


### PR DESCRIPTION
We previously claimed that this library supports `ApolloServer` instances from both `apollo-server-express` and `apollo-server`.

However, that's not true: we *only* support instances from `apollo-server-express` (See: https://github.com/zapier/apollo-server-integration-testing/issues/4).

This PR updates the README to reflect that.