### PR TITLE
Add auto-formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: ci
+on: [push]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: yarn
+      - run: yarn prettier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,5 +6,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - run: yarn
+      - run: yarn install --ignore-scripts
       - run: yarn prettier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: ci
-on: [push]
+on: [push, pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
-name: ci
-on: [push, pull_request]
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
 jobs:
-  ci:
+  verify:
+    name: Verify Files
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - run: yarn install --ignore-scripts
-      - run: yarn prettier
+      - name: Install Packages
+        run: yarn install --ignore-scripts
+      - name: Check Formatting
+        run: yarn prettier
+      - name: Typecheck Files
+        run: yarn tsc --noEmit

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
   "singleQuote": true,
-  "trailingComma": "none"
+  "trailingComma": "es5"
 }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ setOptions({
 });
 ```
 
-
 ## Why not use `apollo-server-testing`?
 
 You can't really write _real_ integration tests with `apollo-server-testing`, because it doesn't support servers which rely on the `context` option being a function that uses the `req` object ([see this issue for more information](https://github.com/apollographql/apollo-server/issues/2277)).
@@ -148,7 +147,7 @@ If you want to help out, here's a TODO list:
 - [x] Strip flow types before publishing (or switch to Typescript?)
 - [x] Compile to non-es6 module syntax
 - [ ] Add tests
-- [ ] Add auto-formatting
+- [x] Add auto-formatting
 
 ## Support
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "clean": "rm -rf dist/",
     "compile": "tsc",
     "prepublish": "yarn clean && yarn compile",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "prettier": "prettier --check src"
   },
   "dependencies": {
     "apollo-server-core": "^2.9.13",
@@ -29,6 +30,7 @@
     "node-mocks-http": "^1.8.0"
   },
   "devDependencies": {
+    "prettier": "^2.1.2",
     "typescript": "^3.7.3"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import httpMocks, { RequestOptions, ResponseOptions } from 'node-mocks-http';
 const mockRequest = (options: RequestOptions = {}) =>
   httpMocks.createRequest({
     method: 'POST',
-    ...options
+    ...options,
   });
 
 const mockResponse = (options: ResponseOptions = {}) =>
@@ -71,7 +71,7 @@ export type TestSetOptions = (options: {
 export function createTestClient({
   apolloServer,
   extendMockRequest = {},
-  extendMockResponse = {}
+  extendMockResponse = {},
 }: TestClientConfig) {
   const app = express();
   apolloServer.applyMiddleware({ app });
@@ -86,7 +86,7 @@ export function createTestClient({
 
   const setOptions: TestSetOptions = ({
     request,
-    response
+    response,
   }: {
     request?: RequestOptions;
     response?: ResponseOptions;
@@ -117,9 +117,9 @@ export function createTestClient({
       query: {
         // operation can be a string or an AST, but `runHttpQuery` only accepts a string
         query: typeof operation === 'string' ? operation : print(operation),
-        variables
+        variables,
       },
-      request: convertNodeHttpToRequest(req)
+      request: convertNodeHttpToRequest(req),
     });
 
     return JSON.parse(graphqlResponse) as T;
@@ -128,6 +128,6 @@ export function createTestClient({
   return {
     query: test,
     mutate: test,
-    setOptions
+    setOptions,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,6 +924,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+
 proxy-addr@~2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"


### PR DESCRIPTION
I'd like to give a go to #9 but figured there are a few things to do first.

This PR takes a slightly different approach than #4 in the sense that it uses GitHub's CI to check the formatting instead of a git hook. It also adds the Prettier configuration so all developers share the same.

I created a new PR instead of commenting on the current one as it was last updated in August and @geordidearns might have moved on to other things.