### PR TITLE
ENG-434 Bump version to 4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: Verify Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
       - name: Install Packages
         run: yarn install --ignore-scripts
       - name: Check Formatting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-integration-testing",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Test helper for writing apollo-server integration tests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Publishing a major version of the library because dependencies in https://github.com/zapier/apollo-server-integration-testing/pull/22 were bumped major versions.